### PR TITLE
Add CLI menu with notes integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This is a simple PHP application that outputs an HTML page with "Hello World!".
 
 Run it with: `php index.php`
 
+## Menu script
+
+An interactive menu is provided in `menu.php` to access the index page and manage notes:
+
+```
+php menu.php
+```
+
 ## Notes application
 
 A small CLI notepad backed by SQLite is provided in `notes.php`.

--- a/menu.php
+++ b/menu.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/notes.php';
+
+function mainMenu(): void {
+    echo "Main Menu\n";
+    echo "1. Show index page\n";
+    echo "2. Notes\n";
+    echo "3. Exit\n";
+    echo "Select an option: ";
+}
+
+function notesMenu(): void {
+    echo "Notes Menu\n";
+    echo "1. Add note\n";
+    echo "2. List notes\n";
+    echo "3. Back\n";
+    echo "Select an option: ";
+}
+
+while (true) {
+    mainMenu();
+    $choice = trim(fgets(STDIN));
+
+    switch ($choice) {
+        case '1':
+            // Include index.php to output the HTML
+            require __DIR__ . '/index.php';
+            break;
+        case '2':
+            while (true) {
+                notesMenu();
+                $nChoice = trim(fgets(STDIN));
+                if ($nChoice === '1') {
+                    echo "Enter note: ";
+                    $note = trim(fgets(STDIN));
+                    if ($note !== '') {
+                        addNote($db, $note);
+                    }
+                } elseif ($nChoice === '2') {
+                    listNotes($db);
+                } else {
+                    break;
+                }
+            }
+            break;
+        case '3':
+            exit(0);
+        default:
+            echo "Invalid option\n";
+    }
+}

--- a/notes.php
+++ b/notes.php
@@ -1,4 +1,5 @@
 <?php
+
 $dbFile = __DIR__ . '/notes.db';
 $db = new SQLite3($dbFile);
 
@@ -9,34 +10,52 @@ $db->exec("CREATE TABLE IF NOT EXISTS notes (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 )");
 
-$argv = $_SERVER['argv'];
-$script = array_shift($argv);
-$command = isset($argv[0]) ? $argv[0] : null;
+function addNote(SQLite3 $db, string $note): void
+{
+    $stmt = $db->prepare('INSERT INTO notes(content) VALUES (:content)');
+    $stmt->bindValue(':content', $note, SQLITE3_TEXT);
+    $stmt->execute();
+    echo "Note added.\n";
+}
 
-function showHelp()
+function listNotes(SQLite3 $db): void
+{
+    $results = $db->query('SELECT id, content, created_at FROM notes ORDER BY id ASC');
+    while ($row = $results->fetchArray(SQLITE3_ASSOC)) {
+        echo sprintf("%d | %s | %s\n", $row['id'], $row['created_at'], $row['content']);
+    }
+}
+
+function showHelp(): void
 {
     echo "Usage:\n";
     echo "  php notes.php add \"your note\"   Add a new note\n";
     echo "  php notes.php list                List all notes\n";
 }
 
-if ($command === 'add') {
-    $note = isset($argv[1]) ? $argv[1] : '';
-    if ($note === '') {
-        echo "No note provided.\n";
+function handleCommand(SQLite3 $db, array $argv): int
+{
+    $script = array_shift($argv); // remove script name
+    $command = $argv[0] ?? null;
+
+    if ($command === 'add') {
+        $note = $argv[1] ?? '';
+        if ($note === '') {
+            echo "No note provided.\n";
+            showHelp();
+            return 1;
+        }
+        addNote($db, $note);
+    } elseif ($command === 'list') {
+        listNotes($db);
+    } else {
         showHelp();
-        exit(1);
+        return 1;
     }
-    $stmt = $db->prepare('INSERT INTO notes(content) VALUES (:content)');
-    $stmt->bindValue(':content', $note, SQLITE3_TEXT);
-    $stmt->execute();
-    echo "Note added.\n";
-} elseif ($command === 'list') {
-    $results = $db->query('SELECT id, content, created_at FROM notes ORDER BY id ASC');
-    while ($row = $results->fetchArray(SQLITE3_ASSOC)) {
-        echo sprintf("%d | %s | %s\n", $row['id'], $row['created_at'], $row['content']);
-    }
-} else {
-    showHelp();
-    exit(1);
+
+    return 0;
+}
+
+if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    exit(handleCommand($db, $_SERVER['argv']));
 }


### PR DESCRIPTION
## Summary
- add menu.php script with interactive CLI menu
- refactor notes.php into reusable functions
- document menu usage in README

## Testing
- `php menu.php` *(fails: `php: command not found`)*